### PR TITLE
ci: fix the deployment command for "api"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only -c stats/fly.toml
+      - run: flyctl deploy --remote-only -c api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN_API }}
       - if: failure()


### PR DESCRIPTION
See https://github.com/filecoin-station/deal-observer/actions/runs/12764228257/job/35576003610

```
Run flyctl deploy --remote-only -c stats/fly.toml
Error: the config for your app is missing an app name, add an app field to the fly.toml file or specify with the -a flag
Error: Process completed with exit code 1.
```