### PR TITLE
perf: index active_deals (activated_at_epoch)

### DIFF
--- a/db/migrations/007.do.index-activated-at-epoch.sql
+++ b/db/migrations/007.do.index-activated-at-epoch.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS active_deals_activated_at_epoch_idx
+ON active_deals (activated_at_epoch);


### PR DESCRIPTION
When troubleshooting, I often need to look up all deals activated in a given epoch. Let's create an index to make these queries performant.