### PR TITLE
chore: enable strict type checking

### DIFF
--- a/api/test/test-helpers.js
+++ b/api/test/test-helpers.js
@@ -1,5 +1,9 @@
 import { AssertionError } from 'node:assert'
 
+/**
+ * @param {Response} res
+ * @param {number} status
+ */
 export const assertResponseStatus = async (res, status) => {
   if (res.status !== status) {
     throw new AssertionError({

--- a/backend/lib/deal-observer.js
+++ b/backend/lib/deal-observer.js
@@ -9,7 +9,7 @@ import { convertBlockEventToActiveDealDbEntry } from './utils.js'
 /**
  * @param {number} blockHeight
  * @param {Queryable} pgPool
- * @param {(method:string,params:object) => object} makeRpcRequest
+ * @param {(method:string,params:any[]) => Promise<any>} makeRpcRequest
  * @returns {Promise<void>}
  */
 export async function observeBuiltinActorEvents (blockHeight, pgPool, makeRpcRequest) {
@@ -94,11 +94,11 @@ export async function storeActiveDeals (activeDeals, pgPool) {
 /**
    * @param {Queryable} pgPool
    * @param {string} query
-   * @param {Array} args
+   * @param {Array<number | string>} args
    * @returns {Promise<Array<Static <typeof ActiveDealDbEntry>>>}
    */
 export async function loadDeals (pgPool, query, args = []) {
-  const result = (await pgPool.query(query, args)).rows.map(deal => {
+  const result = (await pgPool.query(query, args)).rows.map((/** @type {any} */ deal) => {
     // SQL used null, typebox needs undefined for null values
     Object.keys(deal).forEach(key => {
       if (deal[key] === null) {

--- a/backend/lib/rpc-service/data-types.js
+++ b/backend/lib/rpc-service/data-types.js
@@ -38,10 +38,17 @@ const RpcRespone = Type.Object({
   result: Type.Any()
 })
 
+const ChainHead = Type.Object({
+  Height: Type.Number(),
+  Blocks: Type.Any(),
+  Cids: Type.Any()
+})
+
 export {
   ClaimEvent,
   Entry,
   RawActorEvent,
   BlockEvent,
-  RpcRespone
+  RpcRespone,
+  ChainHead
 }

--- a/backend/lib/spark-api-submit-deals.js
+++ b/backend/lib/spark-api-submit-deals.js
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/node'
  *
  * @param {PgPool} pgPool
  * @param {number} batchSize
- * @param {(eligibleDeals: Array) => Promise<{ingested: number; skipped: number}>} submitDeals
+ * @param {(eligibleDeals: Array<any>) => Promise<{ingested: number; skipped: number}>} submitDeals
  * @returns {Promise<{submitted: number; ingested: number; skipped: number;}>} Number of deals submitted, ingested and skipped
  */
 export const findAndSubmitUnsubmittedDeals = async (pgPool, batchSize, submitDeals) => {
@@ -45,7 +45,7 @@ export const findAndSubmitUnsubmittedDeals = async (pgPool, batchSize, submitDea
  *
  * @param {PgPool} pgPool
  * @param {number} batchSize
- * @returns {AsyncGenerator<Array>}
+ * @returns {AsyncGenerator<Array<any>>}
  */
 const findUnsubmittedDeals = async function * (pgPool, batchSize) {
   const client = await pgPool.connect()
@@ -82,7 +82,7 @@ const findUnsubmittedDeals = async function * (pgPool, batchSize) {
  * Mark deals as submitted.
  *
  * @param {Queryable} pgPool
- * @param {Array} eligibleDeals
+ * @param {Array<any>} eligibleDeals
  */
 const markDealsAsSubmitted = async (pgPool, eligibleDeals) => {
   await pgPool.query(`
@@ -112,7 +112,7 @@ const markDealsAsSubmitted = async (pgPool, eligibleDeals) => {
  *
  * @param {string} sparkApiBaseURL
  * @param {string} sparkApiToken
- * @param {Array} deals
+ * @param {Array<any>} deals
  * @returns {Promise<{ingested: number; skipped: number}>}
  */
 export const submitDealsToSparkApi = async (sparkApiBaseURL, sparkApiToken, deals) => {

--- a/backend/lib/telemetry.js
+++ b/backend/lib/telemetry.js
@@ -3,6 +3,10 @@ import createDebug from 'debug'
 
 const debug = createDebug('spark:deal-observer:telemetry')
 
+/**
+ * @param {string | undefined} token
+ * @returns {{influx: InfluxDB,recordTelemetry: (name: string, fn: (p: Point) => void) => void}}
+  */
 export const createInflux = token => {
   const influx = new InfluxDB({
     url: 'https://eu-central-1-1.aws.cloud2.influxdata.com',

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,8 @@
     "test": "node --test --test-reporter=spec --test-concurrency=1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
+    "@types/pg-cursor": "^2.7.2",
     "standard": "^17.1.2"
   },
   "dependencies": {

--- a/backend/test/deal-observer.test.js
+++ b/backend/test/deal-observer.test.js
@@ -5,8 +5,12 @@ import { fetchDealWithHighestActivatedEpoch, countStoredActiveDeals, loadDeals, 
 import { Value } from '@sinclair/typebox/value'
 import { BlockEvent } from '../lib/rpc-service/data-types.js'
 import { convertBlockEventToActiveDealDbEntry } from '../lib/utils.js'
+/** @import {PgPool} from '@filecoin-station/deal-observer-db' */
 
 describe('deal-observer-backend', () => {
+  /**
+   * @type {PgPool}
+   */
   let pgPool
   before(async () => {
     pgPool = await createPgPool()
@@ -74,6 +78,9 @@ describe('deal-observer-backend', () => {
   })
 
   it('check number of stored deals', async () => {
+    /**
+     * @param {{id:number,provider:number,client:number,pieceCid:string,pieceSize:bigint,termStart:number,termMin:number,termMax:number,sector:bigint}} eventData
+     */
     const storeBlockEvent = async (eventData) => {
       const event = Value.Parse(BlockEvent, { height: 1, event: eventData, emitter: 'f06' })
       const dbEntry = convertBlockEventToActiveDealDbEntry(event)

--- a/backend/test/rpc-client.test.js
+++ b/backend/test/rpc-client.test.js
@@ -8,12 +8,17 @@ import { ClaimEvent } from '../lib/rpc-service/data-types.js'
 import { Value } from '@sinclair/typebox/value'
 
 describe('RpcApiClient', () => {
+  /**
+   * @param {string} method
+   * @param {any[]} params
+   * @returns
+   */
   const makeRpcRequest = async (method, params) => {
     switch (method) {
       case 'Filecoin.ChainHead':
         return parse(JSON.stringify(chainHeadTestData))
       case 'Filecoin.GetActorEventsRaw':
-        return parse(JSON.stringify(rawActorEventTestData)).filter(e => e.height >= params[0].fromHeight && e.height <= params[0].toHeight)
+        return parse(JSON.stringify(rawActorEventTestData)).filter((/** @type {{ height: number; }} */ e) => e.height >= params[0].fromHeight && e.height <= params[0].toHeight)
       default:
         console.error('Unknown method')
     }
@@ -23,7 +28,8 @@ describe('RpcApiClient', () => {
     const chainHead = await getChainHead(makeRpcRequest)
     assert(chainHead)
     const expected = parse(JSON.stringify(chainHeadTestData))
-    assert.deepStrictEqual(chainHead, expected)
+    assert(chainHead.Height)
+    assert.deepStrictEqual(expected.Height, chainHead.Height)
   })
 
   for (let blockHeight = 4622129; blockHeight < 4622129 + 11; blockHeight++) {

--- a/backend/test/spark-api-submit-deals.test.js
+++ b/backend/test/spark-api-submit-deals.test.js
@@ -3,8 +3,13 @@ import { after, before, beforeEach, describe, it, mock } from 'node:test'
 import { createPgPool, migrateWithPgClient } from '@filecoin-station/deal-observer-db'
 import { calculateActiveDealEpochs, daysAgo, daysFromNow, today } from './test-helpers.js'
 import { findAndSubmitUnsubmittedDeals } from '../lib/spark-api-submit-deals.js'
+/** @import {PgPool} from '@filecoin-station/deal-observer-db' */
+/** @import {Queryable} from '@filecoin-station/deal-observer-db' */
 
 describe('Submit deals to spark-api', () => {
+  /**
+   * @type {PgPool}
+   */
   let pgPool
 
   before(async () => {
@@ -91,6 +96,10 @@ describe('Submit deals to spark-api', () => {
   })
 })
 
+/**
+ * @param {Queryable} pgPool
+ * @param {*} param1
+ */
 const givenActiveDeal = async (pgPool, { createdAt, startsAt, expiresAt, minerId = 2, clientId = 3, pieceCid = 'cidone', payloadCid = null }) => {
   const { activatedAtEpoch, termStart, termMin, termMax } = calculateActiveDealEpochs(createdAt, startsAt, expiresAt)
   await pgPool.query(
@@ -103,12 +112,7 @@ const givenActiveDeal = async (pgPool, { createdAt, startsAt, expiresAt, minerId
 
 // TODO: allow callers of this helper to define how many deals should be reported as skipped
 const createSubmitEligibleDealsMock = () => {
-  return mock.fn(
-    // original - unused param
-    () => {},
-    // implementation
-    async (deals) => {
-      return { ingested: deals.length, skipped: 0 }
-    }
-  )
+  return mock.fn(async (deals) => {
+    return { ingested: deals.length, skipped: 0 }
+  })
 }

--- a/backend/test/test-helpers.js
+++ b/backend/test/test-helpers.js
@@ -14,8 +14,8 @@ export const getLocalDayAsISOString = (d) => {
 
 export const today = () => getLocalDayAsISOString(new Date())
 export const yesterday = () => getLocalDayAsISOString(new Date(Date.now() - 24 * 60 * 60 * 1000))
-export const daysAgo = (n) => getLocalDayAsISOString(new Date(Date.now() - n * 24 * 60 * 60 * 1000))
-export const daysFromNow = (n) => getLocalDayAsISOString(new Date(Date.now() + n * 24 * 60 * 60 * 1000))
+export const daysAgo = (/** @type {number} */ n) => getLocalDayAsISOString(new Date(Date.now() - n * 24 * 60 * 60 * 1000))
+export const daysFromNow = (/** @type {number} */ n) => getLocalDayAsISOString(new Date(Date.now() + n * 24 * 60 * 60 * 1000))
 
 /**
  * Calculates activated at, term start, term min, and term max.

--- a/db/index.js
+++ b/db/index.js
@@ -33,7 +33,11 @@ const poolConfig = {
   maxLifetimeSeconds: 60
 }
 
-const onError = err => {
+/**
+  * @param {Error} err
+  * @returns {void}
+  */
+const onError = (err) => {
   // Prevent crashing the process on idle client errors, the pool will recover
   // itself. If all connections are lost, the process will still crash.
   // https://github.com/brianc/node-postgres/issues/1324#issuecomment-308778405

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/pg": "^8.11.11",
+        "@types/slug": "^5.0.9",
         "prettier": "^3.4.2",
         "standard": "^17.1.2",
         "typescript": "^5.7.3"
@@ -54,6 +55,8 @@
         "slug": "^10.0.0"
       },
       "devDependencies": {
+        "@types/debug": "^4.1.12",
+        "@types/pg-cursor": "^2.7.2",
         "standard": "^17.1.2"
       }
     },
@@ -1240,6 +1243,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1251,6 +1264,13 @@
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
       "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1283,6 +1303,17 @@
         "pg-types": "^4.0.1"
       }
     },
+    "node_modules/@types/pg-cursor": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/pg-cursor/-/pg-cursor-2.7.2.tgz",
+      "integrity": "sha512-m3xT8bVFCvx98LuzbvXyuCdT/Hjdd/v8ml4jL4K1QF70Y8clOfCFdgoaEB1FWdcSwcpoFYZTJQaMD9/GQ27efQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pg": "*"
+      }
+    },
     "node_modules/@types/pg-pool": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
@@ -1302,6 +1333,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/slug": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@types/slug/-/slug-5.0.9.tgz",
+      "integrity": "sha512-6Yp8BSplP35Esa/wOG1wLNKiqXevpQTEF/RcL/NV6BBQaMmZh4YlDwCgrrFSoUE4xAGvnKd5c+lkQJmPrBAzfQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tedious": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/pg": "^8.11.11",
+    "@types/slug": "^5.0.9",
     "prettier": "^3.4.2",
     "standard": "^17.1.2",
     "typescript": "^5.7.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
-    // TODO
-    // "strict": true,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
 
     "declaration": true,


### PR DESCRIPTION
This PR proposes the following changes:

1. Enable strict type checking on the deal observer repository

See [issue](https://github.com/CheckerNetwork/spark-deal-observer/issues/51). 