### PR TITLE
update naming: index pieces -> look up payload CIDs

### DIFF
--- a/backend/bin/deal-observer-backend.js
+++ b/backend/bin/deal-observer-backend.js
@@ -8,7 +8,7 @@ import '../lib/instrument.js'
 import { createInflux } from '../lib/telemetry.js'
 import { getChainHead, rpcRequest } from '../lib/rpc-service/service.js'
 import { fetchDealWithHighestActivatedEpoch, countStoredActiveDeals, observeBuiltinActorEvents } from '../lib/deal-observer.js'
-import { indexPieces } from '../lib/piece-indexer.js'
+import { lookUpPayloadCids } from '../lib/look-up-payload-cids.js'
 import { findAndSubmitUnsubmittedDeals, submitDealsToSparkApi } from '../lib/spark-api-submit-deals.js'
 import { getDealPayloadCid } from '../lib/piece-indexer-service.js'
 
@@ -126,14 +126,14 @@ const sparkApiSubmitDealsLoop = async (pgPool, { sparkApiBaseUrl, sparkApiToken,
   }
 }
 
-export const pieceIndexerLoop = async (makeRpcRequest, getDealPayloadCid, pgPool) => {
-  const LOOP_NAME = 'Piece Indexer'
+export const lookUpPayloadCidsLoop = async (makeRpcRequest, getDealPayloadCid, pgPool) => {
+  const LOOP_NAME = 'Look up payload CIDs'
   while (true) {
     const start = Date.now()
-    // Maximum number of deals to index in one loop iteration
+    // Maximum number of deals to look up payload CIDs for in one loop iteration
     const maxDeals = 1000
     try {
-      await indexPieces(makeRpcRequest, getDealPayloadCid, pgPool, maxDeals)
+      await lookUpPayloadCids(makeRpcRequest, getDealPayloadCid, pgPool, maxDeals)
     } catch (e) {
       console.error(e)
       Sentry.captureException(e)
@@ -155,7 +155,7 @@ export const pieceIndexerLoop = async (makeRpcRequest, getDealPayloadCid, pgPool
 }
 
 await Promise.all([
-  pieceIndexerLoop(rpcRequest, getDealPayloadCid, pgPool),
+  lookUpPayloadCidsLoop(rpcRequest, getDealPayloadCid, pgPool),
   observeActorEventsLoop(rpcRequest, pgPool),
   sparkApiSubmitDealsLoop(pgPool, {
     sparkApiBaseUrl: SPARK_API_BASE_URL,

--- a/backend/lib/look-up-payload-cids.js
+++ b/backend/lib/look-up-payload-cids.js
@@ -14,7 +14,7 @@ import { getMinerPeerId } from './rpc-service/service.js'
  * @param {number} maxDeals
  * @returns {Promise<void>}
  */
-export const indexPieces = async (makeRpcRequest, getDealPayloadCid, pgPool, maxDeals) => {
+export const lookUpPayloadCids = async (makeRpcRequest, getDealPayloadCid, pgPool, maxDeals) => {
   for (const deal of await fetchDealsWithNoPayloadCid(pgPool, maxDeals)) {
     const minerPeerId = await getMinerPeerId(deal.miner_id, makeRpcRequest)
     const payloadCid = await getDealPayloadCid(minerPeerId, deal.piece_cid)
@@ -30,7 +30,7 @@ export const indexPieces = async (makeRpcRequest, getDealPayloadCid, pgPool, max
    * @param {number} maxDeals
    * @returns {Promise<Array<Static< typeof ActiveDealDbEntry>>>}
    */
-export async function fetchDealsWithNoPayloadCid (pgPool, maxDeals) {
+async function fetchDealsWithNoPayloadCid (pgPool, maxDeals) {
   const query = 'SELECT * FROM active_deals WHERE payload_cid IS NULL ORDER BY activated_at_epoch ASC LIMIT $1'
   return await loadDeals(pgPool, query, [maxDeals])
 }

--- a/backend/test/look-up-payload-cids.test.js
+++ b/backend/test/look-up-payload-cids.test.js
@@ -7,9 +7,9 @@ import { observeBuiltinActorEvents } from '../lib/deal-observer.js'
 import assert from 'assert'
 import { minerPeerIds } from './test_data/minerInfo.js'
 import { payloadCIDs } from './test_data/payloadCIDs.js'
-import { indexPieces } from '../lib/piece-indexer.js'
+import { lookUpPayloadCids } from '../lib/look-up-payload-cids.js'
 
-describe('deal-observer-backend piece indexer', () => {
+describe('deal-observer-backend look up payload CIDs', () => {
   const makeRpcRequest = async (method, params) => {
     switch (method) {
       case 'Filecoin.ChainHead':
@@ -56,7 +56,7 @@ describe('deal-observer-backend piece indexer', () => {
       (await pgPool.query('SELECT * FROM active_deals WHERE payload_cid IS NULL')).rows.length,
       336
     )
-    await indexPieces(makeRpcRequest, getDealPayloadCid, pgPool, 10000)
+    await lookUpPayloadCids(makeRpcRequest, getDealPayloadCid, pgPool, 10000)
     assert.strictEqual(getDealPayloadCidCalls.length, 336)
     assert.strictEqual(
       (await pgPool.query('SELECT * FROM active_deals WHERE payload_cid IS NULL')).rows.length,


### PR DESCRIPTION
As I was trying to suggest more consistent naming for https://github.com/CheckerNetwork/spark-deal-observer/pull/84, I realized that existing naming had issues.

Most notably, this service does not `indexPieces()`, what it does is call out to the `piece-indexer` service, to look up payload CIDs. This PR fixes that.