### PR TITLE
fix: consistent naming for resolving payloads

### DIFF
--- a/backend/bin/deal-observer-backend.js
+++ b/backend/bin/deal-observer-backend.js
@@ -8,9 +8,9 @@ import '../lib/instrument.js'
 import { createInflux } from '../lib/telemetry.js'
 import { rpcRequest } from '../lib/rpc-service/service.js'
 import { fetchDealWithHighestActivatedEpoch, countStoredActiveDeals, observeBuiltinActorEvents } from '../lib/deal-observer.js'
-import { countStoredActiveDealsWithUnresolvedPayloadCid, lookUpPayloadCids } from '../lib/look-up-payload-cids.js'
+import { countStoredActiveDealsWithUnresolvedPayloadCid, resolvePayloadCids } from '../lib/resolve-payload-cids.js'
 import { findAndSubmitUnsubmittedDeals, submitDealsToSparkApi } from '../lib/spark-api-submit-deals.js'
-import { getDealPayloadCid } from '../lib/piece-indexer-service.js'
+import { resolvePayloadCid } from '../lib/piece-indexer-service.js'
 /** @import {Queryable} from '@filecoin-station/deal-observer-db' */
 
 const {
@@ -117,19 +117,19 @@ const sparkApiSubmitDealsLoop = async (pgPool, { sparkApiBaseUrl, sparkApiToken,
   }
 }
 
-export const lookUpPayloadCidsLoop = async (makeRpcRequest, getDealPayloadCid, pgPool) => {
-  const LOOP_NAME = 'Look up payload CIDs'
+export const resolvePayloadCidsLoop = async (makeRpcRequest, resolvePayloadCid, pgPool) => {
+  const LOOP_NAME = 'Resolve payload CIDs'
   while (true) {
     const start = Date.now()
-    // Maximum number of deals to look up payload CIDs for in one loop iteration
+    // Maximum number of deals to resolve payload CIDs for in one loop iteration
     const maxDeals = 1000
     try {
-      const numOfPayloadCidsResolved = await lookUpPayloadCids(makeRpcRequest, getDealPayloadCid, pgPool, maxDeals)
+      const numOfPayloadCidsResolved = await resolvePayloadCids(makeRpcRequest, resolvePayloadCid, pgPool, maxDeals)
       const numOfUnresolvedPayloadCids = await countStoredActiveDealsWithUnresolvedPayloadCid(pgPool)
       if (INFLUXDB_TOKEN) {
-        recordTelemetry('look_up_payload_cids_stats', point => {
+        recordTelemetry('resolve_payload_cids_stats', point => {
           point.intField('total_unresolved_payload_cids', numOfUnresolvedPayloadCids)
-          point.intField('payload_cids_resolved', numOfPayloadCidsResolved)
+          point.intField('resolved_payload_cids', numOfPayloadCidsResolved)
         })
       }
     } catch (e) {
@@ -153,7 +153,7 @@ export const lookUpPayloadCidsLoop = async (makeRpcRequest, getDealPayloadCid, p
 }
 
 await Promise.all([
-  lookUpPayloadCidsLoop(rpcRequest, getDealPayloadCid, pgPool),
+  resolvePayloadCidsLoop(rpcRequest, resolvePayloadCid, pgPool),
   observeActorEventsLoop(rpcRequest, pgPool),
   sparkApiSubmitDealsLoop(pgPool, {
     sparkApiBaseUrl: SPARK_API_BASE_URL,

--- a/backend/lib/piece-indexer-service.js
+++ b/backend/lib/piece-indexer-service.js
@@ -16,7 +16,7 @@ const PieceIndexerErrorResponse = Type.Object({
  * @param {string} pieceCid
  * @returns {Promise<string|null>}
  */
-export const getDealPayloadCid = async (providerId, pieceCid) => {
+export const resolvePayloadCid = async (providerId, pieceCid) => {
   const url = PIECE_INDEXER_URL + '/sample/' + providerId + '/' + pieceCid
   try {
     const response = await pRetry(async () => await fetch(url, {
@@ -30,7 +30,7 @@ export const getDealPayloadCid = async (providerId, pieceCid) => {
       if (parsedPixResponse.error === 'PROVIDER_OR_PIECE_NOT_FOUND') {
         return null
       }
-    } catch {}
+    } catch { }
 
     try {
       const parsedPixResponse = Value.Parse(PieceIndexerResponse, json)

--- a/backend/lib/piece-indexer-service.js
+++ b/backend/lib/piece-indexer-service.js
@@ -16,7 +16,7 @@ const PieceIndexerErrorResponse = Type.Object({
  * @param {string} pieceCid
  * @returns {Promise<string|null>}
  */
-export const resolvePayloadCid = async (providerId, pieceCid) => {
+export const payloadCidRequest = async (providerId, pieceCid) => {
   const url = PIECE_INDEXER_URL + '/sample/' + providerId + '/' + pieceCid
   try {
     const response = await pRetry(async () => await fetch(url, {

--- a/backend/lib/resolve-payload-cids.js
+++ b/backend/lib/resolve-payload-cids.js
@@ -12,16 +12,16 @@ const THREE_DAYS_IN_MILLISECONDS = 1000 * 60 * 60 * 24 * 3
 /**
  *
  * @param {function} makeRpcRequest
- * @param {function} resolvePayloadCid
+ * @param {function} makePayloadCidRequest
  * @param {Queryable} pgPool
  * @param {number} maxDeals
  * @returns {Promise<number>}
  */
-export const resolvePayloadCids = async (makeRpcRequest, resolvePayloadCid, pgPool, maxDeals, now = Date.now()) => {
+export const resolvePayloadCids = async (makeRpcRequest, makePayloadCidRequest, pgPool, maxDeals, now = Date.now()) => {
   let payloadCidsResolved = 0
   for (const deal of await fetchDealsWithUnresolvedPayloadCid(pgPool, maxDeals, new Date(now - THREE_DAYS_IN_MILLISECONDS))) {
     const minerPeerId = await getMinerPeerId(deal.miner_id, makeRpcRequest)
-    deal.payload_cid = await resolvePayloadCid(minerPeerId, deal.piece_cid)
+    deal.payload_cid = await makePayloadCidRequest(minerPeerId, deal.piece_cid)
     if (!deal.payload_cid) {
       if (deal.last_payload_retrieval_attempt) {
         deal.payload_retrievability_state = PayloadRetrievabilityState.TerminallyUnretrievable

--- a/backend/test/piece-indexer-service.test.js
+++ b/backend/test/piece-indexer-service.test.js
@@ -1,11 +1,11 @@
 import { it, describe } from 'node:test'
-import { getDealPayloadCid } from '../lib/piece-indexer-service.js'
+import { resolvePayloadCid } from '../lib/piece-indexer-service.js'
 import assert from 'node:assert/strict'
 
 describe('piece-indexer-service', () => {
   describe('integration', () => {
     it('ignores missing deal payload cids', async () => {
-      const sample = await getDealPayloadCid('f0notfound', 'bafynotfound')
+      const sample = await resolvePayloadCid('f0notfound', 'bafynotfound')
       assert.strictEqual(sample, null)
     })
   })

--- a/backend/test/piece-indexer-service.test.js
+++ b/backend/test/piece-indexer-service.test.js
@@ -1,11 +1,11 @@
 import { it, describe } from 'node:test'
-import { resolvePayloadCid } from '../lib/piece-indexer-service.js'
+import { payloadCidRequest } from '../lib/piece-indexer-service.js'
 import assert from 'node:assert/strict'
 
 describe('piece-indexer-service', () => {
   describe('integration', () => {
     it('ignores missing deal payload cids', async () => {
-      const sample = await resolvePayloadCid('f0notfound', 'bafynotfound')
+      const sample = await payloadCidRequest('f0notfound', 'bafynotfound')
       assert.strictEqual(sample, null)
     })
   })

--- a/backend/test/resolve-payload-cids.test.js
+++ b/backend/test/resolve-payload-cids.test.js
@@ -9,9 +9,9 @@ import { minerPeerIds } from './test_data/minerInfo.js'
 import { payloadCIDs } from './test_data/payloadCIDs.js'
 import { Value } from '@sinclair/typebox/value'
 import { ActiveDealDbEntry, PayloadRetrievabilityState } from '@filecoin-station/deal-observer-db/lib/types.js'
-import { countStoredActiveDealsWithUnresolvedPayloadCid, lookUpPayloadCids } from '../lib/look-up-payload-cids.js'
+import { countStoredActiveDealsWithUnresolvedPayloadCid, resolvePayloadCids } from '../lib/resolve-payload-cids.js'
 
-describe('deal-observer-backend look up payload CIDs', () => {
+describe('deal-observer-backend resolve payload CIDs', () => {
   const makeRpcRequest = async (method, params) => {
     switch (method) {
       case 'Filecoin.ChainHead':
@@ -47,9 +47,9 @@ describe('deal-observer-backend look up payload CIDs', () => {
   })
 
   it('piece indexer loop function fetches deals where there exists no payload yet and updates the database entry', async (t) => {
-    const getDealPayloadCidCalls = []
-    const getDealPayloadCid = async (providerId, pieceCid) => {
-      getDealPayloadCidCalls.push({ providerId, pieceCid })
+    const resolvePayloadCidCalls = []
+    const resolvePayloadCid = async (providerId, pieceCid) => {
+      resolvePayloadCidCalls.push({ providerId, pieceCid })
       const payloadCid = payloadCIDs.get(JSON.stringify({ minerId: providerId, pieceCid }))
       return payloadCid?.payloadCid
     }
@@ -58,27 +58,27 @@ describe('deal-observer-backend look up payload CIDs', () => {
       (await pgPool.query('SELECT * FROM active_deals WHERE payload_cid IS NULL')).rows.length,
       336
     )
-    await lookUpPayloadCids(makeRpcRequest, getDealPayloadCid, pgPool, 10000)
-    assert.strictEqual(getDealPayloadCidCalls.length, 336)
+    await resolvePayloadCids(makeRpcRequest, resolvePayloadCid, pgPool, 10000)
+    assert.strictEqual(resolvePayloadCidCalls.length, 336)
     assert.strictEqual(
       (await pgPool.query('SELECT * FROM active_deals WHERE payload_cid IS NULL')).rows.length,
       85 // Not all deals have a payload CID in the test data
     )
   })
 
-  it('piece indexer count number of missing payload CIDs', async () => {
-    let missingPayloadCids = await countStoredActiveDealsWithUnresolvedPayloadCid(pgPool)
-    assert.strictEqual(missingPayloadCids, 336n)
-    const getDealPayloadCidCalls = []
-    const getDealPayloadCid = async (providerId, pieceCid) => {
-      getDealPayloadCidCalls.push({ providerId, pieceCid })
+  it('piece indexer count number of unresolved payload CIDs', async () => {
+    let unresolvedPayloadCids = await countStoredActiveDealsWithUnresolvedPayloadCid(pgPool)
+    assert.strictEqual(unresolvedPayloadCids, 336n)
+    const resolvePayloadCidCalls = []
+    const resolvePayloadCid = async (providerId, pieceCid) => {
+      resolvePayloadCidCalls.push({ providerId, pieceCid })
       const payloadCid = payloadCIDs.get(JSON.stringify({ minerId: providerId, pieceCid }))
       return payloadCid?.payloadCid
     }
 
-    await lookUpPayloadCids(makeRpcRequest, getDealPayloadCid, pgPool, 10000)
-    missingPayloadCids = await countStoredActiveDealsWithUnresolvedPayloadCid(pgPool)
-    assert.strictEqual(missingPayloadCids, 85n)
+    await resolvePayloadCids(makeRpcRequest, resolvePayloadCid, pgPool, 10000)
+    unresolvedPayloadCids = await countStoredActiveDealsWithUnresolvedPayloadCid(pgPool)
+    assert.strictEqual(unresolvedPayloadCids, 85n)
   })
 })
 
@@ -104,10 +104,10 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
   beforeEach(async () => {
     await pgPool.query('DELETE FROM active_deals')
   })
-  it('piece indexer does not retry to fetch missing payloads if the last retrieval was too recent', async (t) => {
+  it('piece indexer does not retry to fetch unresolved payloads if the last retrieval was too recent', async (t) => {
     const returnPayload = false
     let payloadsCalled = 0
-    const getDealPayloadCid = async () => {
+    const resolvePayloadCid = async () => {
       payloadsCalled++
       return returnPayload ? payloadCid : null
     }
@@ -130,21 +130,21 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
     await storeActiveDeals([deal], pgPool)
     assert.deepStrictEqual((await loadDeals(pgPool, 'SELECT * FROM active_deals'))[0], deal)
     // The payload is unretrievable and the last retrieval timestamp should be updated
-    await lookUpPayloadCids(fetchMinerId, getDealPayloadCid, pgPool, 10000, now)
+    await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     // The timestamp on when the last retrieval of the payload was, was not yet set, so the piece indexer will try to fetch the payload
     assert.strictEqual(payloadsCalled, 1)
     deal.last_payload_retrieval_attempt = new Date(now)
     deal.payload_retrievability_state = PayloadRetrievabilityState.Unresolved
     assert.deepStrictEqual((await loadDeals(pgPool, 'SELECT * FROM active_deals'))[0], deal)
     // If we retry now without changing the field last_payload_retrieval_attempt the function for calling payload should not be called
-    await lookUpPayloadCids(fetchMinerId, getDealPayloadCid, pgPool, 10000, now)
+    await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     assert.strictEqual(payloadsCalled, 1)
   })
 
   it('piece indexer sets the payload to be unretrievable if the second attempt fails', async (t) => {
     const returnPayload = false
     let payloadsCalled = 0
-    const getDealPayloadCid = async () => {
+    const resolvePayloadCid = async () => {
       payloadsCalled++
       return returnPayload ? payloadCid : null
     }
@@ -165,21 +165,21 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
     })
 
     await storeActiveDeals([deal], pgPool)
-    await lookUpPayloadCids(fetchMinerId, getDealPayloadCid, pgPool, 10000, now)
+    await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     assert.strictEqual(payloadsCalled, 1)
     // This is the second attempt that failed to fetch the payload CID so the deal should be marked as unretrievable
     deal.payload_retrievability_state = PayloadRetrievabilityState.TerminallyUnretrievable
     deal.last_payload_retrieval_attempt = new Date(now)
     assert.deepStrictEqual((await loadDeals(pgPool, 'SELECT * FROM active_deals'))[0], deal)
     // Now the piece indexer should no longer call the payload request for this deal
-    await lookUpPayloadCids(fetchMinerId, getDealPayloadCid, pgPool, 10000, now)
+    await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     assert.strictEqual(payloadsCalled, 1)
   })
 
   it('piece indexer correctly udpates the payloads if the retry succeeeds', async (t) => {
     const returnPayload = true
     let payloadsCalled = 0
-    const getDealPayloadCid = async () => {
+    const resolvePayloadCid = async () => {
       payloadsCalled++
       return returnPayload ? payloadCid : null
     }
@@ -200,7 +200,7 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
     })
 
     await storeActiveDeals([deal], pgPool)
-    await lookUpPayloadCids(fetchMinerId, getDealPayloadCid, pgPool, 10000, now)
+    await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     assert.strictEqual(payloadsCalled, 1)
     deal.last_payload_retrieval_attempt = new Date(now)
     deal.payload_cid = payloadCid
@@ -209,7 +209,7 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
     assert.deepStrictEqual((await loadDeals(pgPool, 'SELECT * FROM active_deals'))[0], deal)
 
     // Now the piece indexer should no longer call the payload request for this deal
-    await lookUpPayloadCids(fetchMinerId, getDealPayloadCid, pgPool, 10000, now)
+    await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     assert.strictEqual(payloadsCalled, 1)
   })
 })

--- a/backend/test/resolve-payload-cids.test.js
+++ b/backend/test/resolve-payload-cids.test.js
@@ -129,7 +129,7 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
 
     await storeActiveDeals([deal], pgPool)
     assert.deepStrictEqual((await loadDeals(pgPool, 'SELECT * FROM active_deals'))[0], deal)
-    // The payload is unretrievable and the last retrieval timestamp should be updated
+    // The payload is unresolvable and the last retrieval timestamp should be updated
     await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     // The timestamp on when the last retrieval of the payload was, was not yet set, so the piece indexer will try to fetch the payload
     assert.strictEqual(payloadsCalled, 1)
@@ -141,7 +141,7 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
     assert.strictEqual(payloadsCalled, 1)
   })
 
-  it('piece indexer sets the payload to be unretrievable if the second attempt fails', async (t) => {
+  it('piece indexer sets the payload to be unresolvable if the second attempt fails', async (t) => {
     const returnPayload = false
     let payloadsCalled = 0
     const resolvePayloadCid = async () => {
@@ -167,7 +167,7 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
     await storeActiveDeals([deal], pgPool)
     await resolvePayloadCids(fetchMinerId, resolvePayloadCid, pgPool, 10000, now)
     assert.strictEqual(payloadsCalled, 1)
-    // This is the second attempt that failed to fetch the payload CID so the deal should be marked as unretrievable
+    // This is the second attempt that failed to fetch the payload CID so the deal should be marked as unresolvable
     deal.payload_retrievability_state = PayloadRetrievabilityState.TerminallyUnretrievable
     deal.last_payload_retrieval_attempt = new Date(now)
     assert.deepStrictEqual((await loadDeals(pgPool, 'SELECT * FROM active_deals'))[0], deal)


### PR DESCRIPTION
We want consistent naming for resolving payload CIDs:
The action is `resolving` the state is `resolved` or `unresolved`. 

Closes #87 