### PR TITLE
add SubmittableDeal type

### DIFF
--- a/backend/lib/spark-api-submit-deals.js
+++ b/backend/lib/spark-api-submit-deals.js
@@ -1,6 +1,5 @@
 /** @import {PgPool, Queryable} from '@filecoin-station/deal-observer-db' */
 /** @import { Static } from '@sinclair/typebox' */
-/** @import { ActiveDealDbEntry, PayloadRetrievabilityStateType } from '@filecoin-station/deal-observer-db/lib/types.js' */
 import Cursor from 'pg-cursor'
 import * as Sentry from '@sentry/node'
 import { Type } from '@sinclair/typebox'
@@ -49,7 +48,7 @@ export const findAndSubmitUnsubmittedDeals = async (pgPool, batchSize, submitDea
  *
  * @param {PgPool} pgPool
  * @param {number} batchSize
- * @returns {AsyncGenerator<Array<Static<typeof SubmittableDeal>>, void, unknown>}
+ * @returns {AsyncGenerator<Array<Static<typeof SubmittableDeal>>>}
  */
 const findUnsubmittedDeals = async function * (pgPool, batchSize) {
   const client = await pgPool.connect()


### PR DESCRIPTION
We are currently not using a specific type when submitting deals through the deal observer backend. 
In two recent discussions ([Here](https://github.com/CheckerNetwork/spark-deal-observer/pull/92#issuecomment-2647927720) and [here](https://github.com/CheckerNetwork/spark-deal-observer/pull/80#discussion_r1940940641)), the need for a specific type for submittable deals has come up. 

This PR suggests a new type for deals that are found to be submittable and used throughout the submitting process of the deal observer. 
This solves the issue of the use of the any type when activating type checking and also delivers clarity on the type returned by various functions during the submitting process. 