### PR TITLE
add reverted field to database

### DIFF
--- a/backend/bin/deal-observer-backend.js
+++ b/backend/bin/deal-observer-backend.js
@@ -8,7 +8,7 @@ import '../lib/instrument.js'
 import { createInflux } from '../lib/telemetry.js'
 import { rpcRequest } from '../lib/rpc-service/service.js'
 import { fetchDealWithHighestActivatedEpoch, countStoredActiveDeals, observeBuiltinActorEvents } from '../lib/deal-observer.js'
-import { countStoredActiveDealsWithUnresolvedPayloadCid, lookUpPayloadCids } from '../lib/look-up-payload-cids.js'
+import { countRevertedActiveDeals, countStoredActiveDealsWithUnresolvedPayloadCid, lookUpPayloadCids } from '../lib/look-up-payload-cids.js'
 import { findAndSubmitUnsubmittedDeals, submitDealsToSparkApi } from '../lib/spark-api-submit-deals.js'
 import { getDealPayloadCid } from '../lib/piece-indexer-service.js'
 /** @import {Queryable} from '@filecoin-station/deal-observer-db' */
@@ -46,10 +46,12 @@ const observeActorEventsLoop = async (makeRpcRequest, pgPool) => {
       await observeBuiltinActorEvents(pgPool, makeRpcRequest, maxPastEpochs, finalityEpochs)
       const newLastInsertedDeal = await fetchDealWithHighestActivatedEpoch(pgPool)
       const numberOfStoredDeals = await countStoredActiveDeals(pgPool)
+      const numberOfRevertedActiveDeals = await countRevertedActiveDeals(pgPool)
       if (INFLUXDB_TOKEN) {
         recordTelemetry('observed_deals_stats', point => {
           point.intField('last_searched_epoch', newLastInsertedDeal.activated_at_epoch)
           point.intField('number_of_stored_active_deals', numberOfStoredDeals)
+          point.intField('number_of_reverted_active_deals', numberOfRevertedActiveDeals)
         })
       }
     } catch (e) {

--- a/backend/lib/deal-observer.js
+++ b/backend/lib/deal-observer.js
@@ -81,7 +81,8 @@ export async function storeActiveDeals (activeDeals, pgPool) {
           term_max,
           sector_id,
           payload_retrievability_state,
-          last_payload_retrieval_attempt
+          last_payload_retrieval_attempt,
+          reverted
         )
         VALUES (
           unnest($1::int[]),
@@ -94,8 +95,8 @@ export async function storeActiveDeals (activeDeals, pgPool) {
           unnest($8::int[]), 
           unnest($9::bigint[]),
           unnest($10::payload_retrievability_state[]),
-          unnest($11::timestamp[])
-
+          unnest($11::timestamp[]),
+          unnest($12::boolean[])
         )
       `
     await pgPool.query(insertQuery, [
@@ -109,7 +110,8 @@ export async function storeActiveDeals (activeDeals, pgPool) {
       activeDeals.map(deal => deal.term_max),
       activeDeals.map(deal => deal.sector_id),
       activeDeals.map(deal => deal.payload_retrievability_state),
-      activeDeals.map(deal => deal.last_payload_retrieval_attempt)
+      activeDeals.map(deal => deal.last_payload_retrieval_attempt),
+      activeDeals.map(deal => deal.reverted)
     ])
   } catch (error) {
     // If any error occurs, roll back the transaction

--- a/backend/lib/look-up-payload-cids.js
+++ b/backend/lib/look-up-payload-cids.js
@@ -56,6 +56,16 @@ export async function countStoredActiveDealsWithUnresolvedPayloadCid (pgPool) {
 }
 
 /**
+  * @param {Queryable} pgPool
+  * @returns {Promise<Array<Static<typeof ActiveDealDbEntry>>>}
+  */
+export async function countRevertedActiveDeals (pgPool) {
+  const query = 'SELECT COUNT(*) FROM active_deals WHERE reverted = TRUE'
+  const result = await pgPool.query(query)
+  return result.rows[0].count
+}
+
+/**
  * @param {Queryable} pgPool
  * @param {Static<typeof ActiveDealDbEntry>} deal
  * @param {Static< typeof PayloadRetrievabilityStateType>} newPayloadRetrievalState

--- a/backend/lib/rpc-service/data-types.js
+++ b/backend/lib/rpc-service/data-types.js
@@ -31,7 +31,8 @@ const RawActorEvent = Type.Object({
 const BlockEvent = Type.Object({
   height: Type.Number(),
   emitter: Type.String(),
-  event: ClaimEvent
+  event: ClaimEvent,
+  reverted: Type.Boolean()
 })
 
 const RpcRespone = Type.Object({

--- a/backend/lib/rpc-service/service.js
+++ b/backend/lib/rpc-service/service.js
@@ -67,7 +67,8 @@ export async function getActorEvents (actorEventFilter, makeRpcRequest) {
             {
               height: typedEventEntries.height,
               emitter: typedEventEntries.emitter,
-              event: typedEvent
+              event: typedEvent,
+              reverted: typedEventEntries.reverted
             }))
         continue
       }

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -21,6 +21,7 @@ export function convertBlockEventToActiveDealDbEntry (blockEvent) {
     sector_id: blockEvent.event.sector,
     payload_cid: undefined,
     payload_retrievability_state: PayloadRetrievabilityState.NotQueried,
-    last_payload_retrieval_attempt: undefined
+    last_payload_retrieval_attempt: undefined,
+    reverted: blockEvent.reverted
   })
 }

--- a/backend/test/look-up-payload-cids.test.js
+++ b/backend/test/look-up-payload-cids.test.js
@@ -124,7 +124,8 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
       sector_id: 1,
       payload_cid: undefined,
       payload_retrievability_state: PayloadRetrievabilityState.NotQueried,
-      last_payload_retrieval_attempt: undefined
+      last_payload_retrieval_attempt: undefined,
+      reverted: false
     })
 
     await storeActiveDeals([deal], pgPool)
@@ -161,7 +162,8 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
       sector_id: 1,
       payload_cid: undefined,
       payload_retrievability_state: PayloadRetrievabilityState.NotQueried,
-      last_payload_retrieval_attempt: new Date(now - 1000 * 60 * 60 * 24 * 4)
+      last_payload_retrieval_attempt: new Date(now - 1000 * 60 * 60 * 24 * 4),
+      reverted: undefined
     })
 
     await storeActiveDeals([deal], pgPool)
@@ -196,7 +198,8 @@ describe('deal-observer-backend piece indexer payload retrieval', () => {
       sector_id: 1,
       payload_cid: undefined,
       payload_retrievability_state: PayloadRetrievabilityState.NotQueried,
-      last_payload_retrieval_attempt: new Date(now - 1000 * 60 * 60 * 24 * 4)
+      last_payload_retrieval_attempt: new Date(now - 1000 * 60 * 60 * 24 * 4),
+      reverted: false
     })
 
     await storeActiveDeals([deal], pgPool)

--- a/db/lib/types.js
+++ b/db/lib/types.js
@@ -21,7 +21,8 @@ const ActiveDealDbEntry = Type.Object({
   sector_id: Type.BigInt(),
   payload_cid: Type.Optional(Type.String()),
   payload_retrievability_state: PayloadRetrievabilityStateType,
-  last_payload_retrieval_attempt: Type.Optional(Type.Date())
+  last_payload_retrieval_attempt: Type.Optional(Type.Date()),
+  reverted: Type.Optional(Type.Boolean())
 })
 
 export { ActiveDealDbEntry, PayloadRetrievabilityState, PayloadRetrievabilityStateType }


### PR DESCRIPTION
This PR proposes the following changes:

1. Add the `reverted` field to the table of `active_deals` 
2. Count the number of reverted active deals and add them to InfluxDB

The implementation plan for this PR can be found [here](https://github.com/CheckerNetwork/spark-deal-observer/issues/22#issuecomment-2652176274). 
Closes #22 