### PR TITLE
feat: add timeout to get peer id

### DIFF
--- a/backend/lib/resolve-payload-cids.js
+++ b/backend/lib/resolve-payload-cids.js
@@ -142,6 +142,9 @@ export const getPeerId = async (minerId, { smartContract, makeRpcRequest } = { s
   return await getIndexProviderPeerId(
   `f0${minerId}`,
   smartContract,
-  { rpcFn: makeRpcRequest }
+  {
+    rpcFn: makeRpcRequest,
+    signal: AbortSignal.timeout(60_000)
+  }
   )
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "@sinclair/typebox": "^0.34.33",
     "debug": "^4.4.0",
     "ethers": "^6.13.5",
-    "index-provider-peer-id": "^1.0.0",
+    "index-provider-peer-id": "^1.0.1",
     "multiformats": "^13.3.2",
     "p-retry": "^6.2.1",
     "pg": "^8.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@sinclair/typebox": "^0.34.33",
         "debug": "^4.4.0",
         "ethers": "^6.13.5",
-        "index-provider-peer-id": "^1.0.0",
+        "index-provider-peer-id": "^1.0.1",
         "multiformats": "^13.3.2",
         "p-retry": "^6.2.1",
         "pg": "^8.14.1",
@@ -3084,9 +3084,9 @@
       }
     },
     "node_modules/index-provider-peer-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/index-provider-peer-id/-/index-provider-peer-id-1.0.0.tgz",
-      "integrity": "sha512-PYJzTFrzjRZfl4clrlFdQzCtjqCQkuxbdegABAIxfa3toSNcflybIUyjGNoN4ovRfA0VqO3Kq6MHMb/T7VPCzg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/index-provider-peer-id/-/index-provider-peer-id-1.0.1.tgz",
+      "integrity": "sha512-XvTNm5ekCajV7veywRVFYTwTBpntR8RSkZ0j2U1eru/ERU+AIxCilQyDfeGi65jh0Jzb3DqcNNtRBlv5F9zvWw==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "ethers": "^6.13.5",


### PR DESCRIPTION
Upgrades the package `index-provider-peer-id` to support the use of abort signals. 
The signal used is a timeout. 
Closes subtask of https://github.com/CheckerNetwork/spark-deal-observer/issues/145