### PR TITLE
perf: add indexes for frequent expensive queries

### DIFF
--- a/db/migrations/013.do.index-active-deals-state.sql
+++ b/db/migrations/013.do.index-active-deals-state.sql
@@ -1,0 +1,4 @@
+CREATE INDEX CONCURRENTLY active_deals_payload_retrievability_state ON active_deals (payload_retrievability_state);
+
+CREATE INDEX CONCURRENTLY active_deals_submittable ON active_deals (submitted_at, payload_cid, activated_at_epoch, term_start_epoch, term_min)
+WHERE submitted_at IS NULL AND payload_cid IS NOT NULL;


### PR DESCRIPTION
I noticed CPU throttling on our DB server. I suspect it's caused by two inefficient queries that can be trivially optimised.

How I discovered the queries:

```
select
  (total_exec_time / 1000 / 3600) as total_hours,
  (total_exec_time / 1000) as total_seconds,
  (total_exec_time / calls) as avg_millis,
  calls num_calls,
  query
from pg_stat_statements
order by 1 desc limit 10;
```

Result:

```
     total_hours      |   total_seconds    |     avg_millis     | num_calls |                                                                                                                             query

----------------------+--------------------+--------------------+-----------+----------------------------------------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------------------------
   1.5545441104524977 |  5596.358797628992 |  1200.935364298067 |      4660 | SELECT COUNT(*) FROM active_deals WHERE payload_retrievability_state = $1
   1.1229233515805546 | 4042.5240656899964 | 3335.4158957838254 |      1212 | WITH two_days_ago AS (
(...)
```

In this patch, I am adding indexes for both queries.
